### PR TITLE
Remove trailing slash.

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -8,7 +8,7 @@ RUN ["rpm", "--import", "/etc/pki/rpm-gpg/GPG-KEY-elasticsearch"]
 RUN ["yum", "install", "-y", "jre >= 1.6.0", "/usr/bin/which"]
 RUN ["yum", "install", "-y", "elasticsearch"]
 
-VOLUME /var/lib/elasticsearch/
+VOLUME /var/lib/elasticsearch
 USER elasticsearch
 CMD  source /etc/sysconfig/elasticsearch; /usr/share/elasticsearch/bin/elasticsearch -p /var/run/elasticsearch/elasticsearch.pid -Des.default.config=$CONF_FILE -Des.default.path.home=$ES_HOME -Des.default.path.logs=$LOG_DIR -Des.default.path.data=$DATA_DIR -Des.default.path.work=$WORK_DIR -Des.default.path.conf=$CONF_DIR
 


### PR DESCRIPTION
Some versions of docker don't ignore trailing slashes in volume specifications.
Since flocker always strips them, we shouldn't specify them.
